### PR TITLE
Refactor: Resolve HTMLRenderer circular dependency & improve profile loading UI

### DIFF
--- a/lib/components/html_renderer.dart
+++ b/lib/components/html_renderer.dart
@@ -6,7 +6,9 @@ import 'package:url_launcher/url_launcher.dart';
 
 class HtmlRenderer extends StatelessWidget {
   final String html;
-  const HtmlRenderer({super.key, required this.html});
+  final void Function(String acctIdentifier)? onMentionTapped;
+
+  const HtmlRenderer({super.key, required this.html, this.onMentionTapped});
 
   @override
   Widget build(BuildContext context) {
@@ -32,7 +34,9 @@ class HtmlRenderer extends StatelessWidget {
 
             return GestureDetector(
               onTap: () {
-                showMastodonProfileBottomSheetWithLoading(context, acct);
+                if (onMentionTapped != null) {
+                  onMentionTapped!(acct);
+                }
               },
               child: Text(element.text,
                   style: TextStyle(

--- a/lib/components/html_renderer.dart
+++ b/lib/components/html_renderer.dart
@@ -1,4 +1,3 @@
-import 'package:fedi_pipe/components/mastodon_profile_bottom_sheet.dart';
 import 'package:fedi_pipe/extensions/string.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_widget_from_html_core/flutter_widget_from_html_core.dart';
@@ -36,6 +35,9 @@ class HtmlRenderer extends StatelessWidget {
               onTap: () {
                 if (onMentionTapped != null) {
                   onMentionTapped!(acct);
+                } else {
+                  print(
+                      "Warning: HtmlRenderer.onMentionTapped is null. Mention for '$acct' was tapped but no action is defined by parent.");
                 }
               },
               child: Text(element.text,

--- a/lib/components/mastodon_profile_bottom_sheet.dart
+++ b/lib/components/mastodon_profile_bottom_sheet.dart
@@ -69,7 +69,12 @@ class MastodonProfileBottomSheet extends StatelessWidget {
             ],
           ),
           SizedBox(height: 16),
-          HtmlRenderer(html: account.note!),
+          HtmlRenderer(
+            html: account.note!,
+            onMentionTapped: (acct) {
+              showMastodonProfileBottomSheetWithLoading(context, acct);
+            },
+          ),
           SizedBox(height: 16),
         ]),
       ),

--- a/lib/components/mastodon_profile_bottom_sheet.dart
+++ b/lib/components/mastodon_profile_bottom_sheet.dart
@@ -4,29 +4,202 @@ import 'package:fedi_pipe/pages/profile_page.dart';
 import 'package:fedi_pipe/repositories/mastodon/account_repository.dart';
 import 'package:flutter/material.dart';
 
+import 'package:fedi_pipe/components/skeletons/profile_skeleton.dart';
+
 void showMastodonProfileBottomSheetWithLoading(BuildContext context, String acct) {
-  MastodonAccountRepository.lookUpAccount(acct).then((account) {
-    showModalBottomSheet(
-      context: context,
-      builder: (context) {
-        return MastodonProfileBottomSheet(account: account);
-      },
-    );
-  });
+  showModalBottomSheet(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: Colors.transparent,
+    builder: (context) {
+      return MastodonProfileBottomSheet(acctIdentifier: acct);
+    },
+  );
 }
 
 void showMastodonProfileBottomSheet(BuildContext context, MastodonAccountModel account) {
   showModalBottomSheet(
     context: context,
+    isScrollControlled: true,
+    backgroundColor: Colors.transparent,
     builder: (context) {
-      return MastodonProfileBottomSheet(account: account);
+      return MastodonProfileBottomSheet(initialAccount: account);
     },
   );
 }
 
-class MastodonProfileBottomSheet extends StatelessWidget {
-  final MastodonAccountModel account;
-  const MastodonProfileBottomSheet({super.key, required this.account});
+class MastodonProfileBottomSheet extends StatefulWidget {
+  final MastodonAccountModel? initialAccount;
+  final String? acctIdentifier;
+
+  const MastodonProfileBottomSheet({
+    super.key,
+    this.initialAccount,
+    this.acctIdentifier,
+  }) : assert(initialAccount != null || acctIdentifier != null,
+              'Either initialAccount or acctIdentifier must be provided');
+
+  @override
+  State<MastodonProfileBottomSheet> createState() => _MastodonProfileBottomSheetState();
+}
+
+class _MastodonProfileBottomSheetState extends State<MastodonProfileBottomSheet> {
+  MastodonAccountModel? _account;
+  bool _isLoading = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.initialAccount != null) {
+      _account = widget.initialAccount;
+      _isLoading = false;
+    } else if (widget.acctIdentifier != null) {
+      _fetchAccountDetails();
+    } else {
+      _isLoading = false;
+      _error = "No account information provided.";
+    }
+  }
+
+  Future<void> _fetchAccountDetails() async {
+    if (widget.acctIdentifier == null) return;
+    setState(() {
+      _isLoading = true;
+      _error = null;
+    });
+    try {
+      final accountData = await MastodonAccountRepository.lookUpAccount(widget.acctIdentifier!);
+      if (mounted) {
+        setState(() {
+          _account = accountData;
+          _isLoading = false;
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _error = "Failed to load profile: ${e.toString()}";
+          _isLoading = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    Widget content;
+    if (_isLoading) {
+      content = MastodonProfileSkeleton(isBottomSheet: true);
+    } else if (_error != null) {
+      content = Padding(
+        padding: const EdgeInsets.all(20.0),
+        child: Center(child: Text(_error!, textAlign: TextAlign.center)),
+      );
+    } else if (_account == null) {
+      content = Padding(
+        padding: const EdgeInsets.all(20.0),
+        child: Center(child: Text('Profile data not available.')),
+      );
+    } else {
+      final currentAccount = _account!;
+      content = SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                GestureDetector(
+                  onTap: () {
+                    Navigator.of(context).pop();
+                    Navigator.of(context).push(MaterialPageRoute(builder: (context) => ProfilePage(initialAccount: currentAccount)));
+                  },
+                  child: CircleAvatar(
+                    radius: 30,
+                    backgroundImage: NetworkImage(currentAccount.avatar ?? ''),
+                    onBackgroundImageError: (_, __) {},
+                  ),
+                ),
+                SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        currentAccount.displayName ?? currentAccount.username,
+                        style: Theme.of(context).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
+                        maxLines: 2, overflow: TextOverflow.ellipsis,
+                      ),
+                      if (currentAccount.acct != null)
+                        Text("@${currentAccount.acct}", style: Theme.of(context).textTheme.titleSmall?.copyWith(color: Colors.grey[600]),
+                           maxLines: 1, overflow: TextOverflow.ellipsis),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            SizedBox(height: 16),
+            if (currentAccount.note != null && currentAccount.note!.isNotEmpty)
+              HtmlRenderer(
+                html: currentAccount.note!,
+                onMentionTapped: (acctIdentifier) {
+                  if (acctIdentifier == currentAccount.acct || "@${acctIdentifier}" == currentAccount.acct) {
+                     Navigator.of(context).pop();
+                     return;
+                  }
+                  Navigator.of(context).pop();
+                  Navigator.of(context).push(MaterialPageRoute(
+                    builder: (context) => ProfilePage(acctIdentifier: acctIdentifier),
+                  ));
+                },
+              ),
+            SizedBox(height: 16),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              children: [
+                _buildStatItem(context, "Followers", currentAccount.followersCount),
+                _buildStatItem(context, "Following", currentAccount.followingCount),
+                _buildStatItem(context, "Posts", currentAccount.statusesCount),
+              ],
+            ),
+            SizedBox(height: 16),
+          ],
+        ),
+      );
+    }
+
+    return ClipRRect(
+      borderRadius: BorderRadius.only(topLeft: Radius.circular(20), topRight: Radius.circular(20)),
+      child: Container(
+        color: Theme.of(context).cardColor,
+        padding: EdgeInsets.only(top: 20, left: 16, right: 16, bottom: MediaQuery.of(context).viewInsets.bottom + 16),
+        constraints: BoxConstraints(
+            maxHeight: MediaQuery.of(context).size.height * 0.75,
+        ),
+        child: content,
+      ),
+    );
+  }
+
+  Widget _buildStatItem(BuildContext context, String label, int count) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          count.toString(),
+          style: Theme.of(context).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+        ),
+        Text(
+          label,
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(color: Colors.grey[600]),
+        ),
+      ],
+    );
+  }
+}
 
   @override
   Widget build(BuildContext context) {

--- a/lib/components/mastodon_status_card.dart
+++ b/lib/components/mastodon_status_card.dart
@@ -582,8 +582,8 @@ class MastodonStatusCardBody extends StatelessWidget {
         padding: const EdgeInsets.all(8.0),
         child: HtmlRenderer(
           html: status.content,
-          onMentionTapped: (acct) {
-            showMastodonProfileBottomSheetWithLoading(context, acct);
+          onMentionTapped: (acctIdentifier) {
+            showMastodonProfileBottomSheetWithLoading(context, acctIdentifier);
           },
         ),
       )

--- a/lib/components/mastodon_status_card.dart
+++ b/lib/components/mastodon_status_card.dart
@@ -580,7 +580,12 @@ class MastodonStatusCardBody extends StatelessWidget {
       ),
       Padding(
         padding: const EdgeInsets.all(8.0),
-        child: HtmlRenderer(html: status.content),
+        child: HtmlRenderer(
+          html: status.content,
+          onMentionTapped: (acct) {
+            showMastodonProfileBottomSheetWithLoading(context, acct);
+          },
+        ),
       )
     ]);
   }

--- a/lib/components/skeletons/profile_skeleton.dart
+++ b/lib/components/skeletons/profile_skeleton.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import 'package:shimmer/shimmer.dart';
+
+class MastodonProfileSkeleton extends StatelessWidget {
+  final bool isBottomSheet;
+
+  const MastodonProfileSkeleton({super.key, this.isBottomSheet = false});
+
+  @override
+  Widget build(BuildContext context) {
+    final baseColor = Colors.grey[300]!;
+    final highlightColor = Colors.grey[100]!;
+
+    return Shimmer.fromColors(
+      baseColor: baseColor,
+      highlightColor: highlightColor,
+      child: SingleChildScrollView(
+        physics: NeverScrollableScrollPhysics(),
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              if (!isBottomSheet)
+                Container(
+                  width: double.infinity,
+                  height: 150.0,
+                  color: Colors.white,
+                ),
+              if (!isBottomSheet) SizedBox(height: 16),
+              Row(
+                crossAxisAlignment: isBottomSheet ? CrossAxisAlignment.center : CrossAxisAlignment.end,
+                children: [
+                  Container(
+                    width: isBottomSheet ? 60.0 : 100.0,
+                    height: isBottomSheet ? 60.0 : 100.0,
+                    decoration: BoxDecoration(
+                      color: Colors.white,
+                      shape: BoxShape.circle,
+                    ),
+                  ),
+                  SizedBox(width: 16),
+                  if (isBottomSheet)
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Container(width: 150, height: 20, color: Colors.white),
+                          SizedBox(height: 8),
+                          Container(width: 100, height: 16, color: Colors.white),
+                        ],
+                      ),
+                    ),
+                  if (!isBottomSheet) Spacer(),
+                  if (!isBottomSheet)
+                    Container(width: 100, height: 36, color: Colors.white, margin: EdgeInsets.only(bottom: isBottomSheet ? 0 : 50)),
+                ],
+              ),
+              if (!isBottomSheet) SizedBox(height: isBottomSheet ? 0 : 8),
+              if (!isBottomSheet)
+                Padding(
+                  padding: EdgeInsets.only(top: isBottomSheet ? 16 : 0),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Container(width: MediaQuery.of(context).size.width * 0.6, height: 24.0, color: Colors.white),
+                      SizedBox(height: 8),
+                      Container(width: MediaQuery.of(context).size.width * 0.4, height: 18.0, color: Colors.white),
+                    ],
+                  ),
+                ),
+              if (isBottomSheet) SizedBox(height: 16),
+              SizedBox(height: 16),
+              Container(width: double.infinity, height: 16.0, color: Colors.white),
+              SizedBox(height: 8),
+              Container(width: double.infinity, height: 16.0, color: Colors.white),
+              SizedBox(height: 8),
+              Container(width: MediaQuery.of(context).size.width * 0.7, height: 16.0, color: Colors.white),
+              SizedBox(height: 24),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceAround,
+                children: List.generate(3, (_) => Column(
+                  children: [
+                    Container(width: 50, height: 20, color: Colors.white),
+                    SizedBox(height: 4),
+                    Container(width: 70, height: 14, color: Colors.white),
+                  ],
+                )),
+              ),
+              SizedBox(height: 16),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/profile_page.dart
+++ b/lib/pages/profile_page.dart
@@ -1,5 +1,6 @@
 import 'package:fedi_pipe/components/html_renderer.dart';
 import 'package:fedi_pipe/models/mastodon_status.dart';
+import 'package:fedi_pipe/repositories/mastodon/account_repository.dart';
 import 'package:flutter/material.dart';
 
 class ProfilePage extends StatelessWidget {
@@ -89,7 +90,32 @@ class ProfilePage extends StatelessWidget {
                     ],
                   ),
                   SizedBox(height: 16),
-                  HtmlRenderer(html: account.note!)
+                  HtmlRenderer(
+                    html: account.note!,
+                    onMentionTapped: (String acctIdentifier) {
+                      if (acctIdentifier == account.acct || "@${acctIdentifier}" == account.acct) {
+                        return;
+                      }
+
+                      showDialog(
+                        context: context,
+                        barrierDismissible: false,
+                        builder: (_) => Center(child: CircularProgressIndicator()),
+                      );
+
+                      MastodonAccountRepository.lookUpAccount(acctIdentifier).then((mentionedAccount) {
+                        Navigator.of(context).pop();
+                        Navigator.of(context).push(MaterialPageRoute(
+                          builder: (context) => ProfilePage(account: mentionedAccount),
+                        ));
+                      }).catchError((error) {
+                        Navigator.of(context).pop();
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(content: Text("Could not load profile for @$acctIdentifier.")),
+                        );
+                      });
+                    },
+                  )
                 ],
               ),
             ),

--- a/lib/pages/profile_page.dart
+++ b/lib/pages/profile_page.dart
@@ -34,6 +34,13 @@ class ProfilePage extends StatefulWidget {
   Widget _buildBody() {
     if (_isLoading) {
       return MastodonProfileSkeleton(isBottomSheet: false);
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _error = "Failed to load profile: ${e.toString()}";
+          _isLoading = false;
+        });
+      }
     }
     if (_error != null) {
       return Center(child: Padding(padding: const EdgeInsets.all(16.0), child: Text(_error!, textAlign: TextAlign.center)));

--- a/lib/pages/profile_page.dart
+++ b/lib/pages/profile_page.dart
@@ -14,18 +14,70 @@ class ProfilePage extends StatefulWidget {
     this.initialAccount,
     this.acctIdentifier,
   }) : assert(initialAccount != null || acctIdentifier != null,
-              'Either initialAccount or acctIdentifier must be provided');
+            'Either initialAccount or acctIdentifier must be provided');
 
   @override
   State<ProfilePage> createState() => _ProfilePageState();
+}
+
+class _ProfilePageState extends State<ProfilePage> {
+  MastodonAccountModel? _account;
+  bool _isLoading = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.initialAccount != null) {
+      _account = widget.initialAccount;
+      _isLoading = false;
+    } else if (widget.acctIdentifier != null) {
+      _fetchAccountDetails();
+    } else {
+      // This case should ideally not be reached due to the assertion
+      // in the widget's constructor.
+      _isLoading = false;
+      _error = "No account information provided.";
+    }
+  }
+
+  Future<void> _fetchAccountDetails() async {
+    if (widget.acctIdentifier == null) return;
+    // Set initial loading state if not already set by initialAccount
+    if (mounted) {
+      // Check if the widget is still in the tree
+      setState(() {
+        _isLoading = true;
+        _error = null;
+      });
+    }
+    try {
+      final account = await MastodonAccountRepository.lookUpAccount(widget.acctIdentifier!);
+      if (mounted) {
+        // Check again before setting state
+        setState(() {
+          _account = account;
+          _isLoading = false;
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        // Check again
+        setState(() {
+          _error = "Failed to load profile: ${e.toString()}";
+          _isLoading = false;
+        });
+      }
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(
-          _isLoading ? 'Loading Profile...' : (_error != null ? 'Error' : (_account?.displayName ?? _account?.username ?? 'Profile'))
-        ),
+        title: Text(_isLoading
+            ? 'Loading Profile...'
+            : (_error != null ? 'Error' : (_account?.displayName ?? _account?.username ?? 'Profile'))),
       ),
       body: _buildBody(),
     );
@@ -34,27 +86,28 @@ class ProfilePage extends StatefulWidget {
   Widget _buildBody() {
     if (_isLoading) {
       return MastodonProfileSkeleton(isBottomSheet: false);
-    } catch (e) {
-      if (mounted) {
-        setState(() {
-          _error = "Failed to load profile: ${e.toString()}";
-          _isLoading = false;
-        });
-      }
     }
+    // Error display should come after loading check
     if (_error != null) {
-      return Center(child: Padding(padding: const EdgeInsets.all(16.0), child: Text(_error!, textAlign: TextAlign.center)));
+      return Center(
+          child: Padding(padding: const EdgeInsets.all(16.0), child: Text(_error!, textAlign: TextAlign.center)));
     }
+    // Check for account null after error and loading
     if (_account == null) {
+      // This could happen if initialAccount and acctIdentifier were both null,
+      // and _fetchAccountDetails wasn't called or failed silently before setting error.
+      // Or if fetch completed but account was still null (API returned null).
       return Center(child: Text('Profile data not available.'));
     }
 
+    // If we've reached here, _account is not null, not loading, and no error.
     final currentAccount = _account!;
 
     return SingleChildScrollView(
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
+          // Header Image
           if (currentAccount.header != null && currentAccount.header!.isNotEmpty)
             Image.network(
               currentAccount.header!,
@@ -71,8 +124,10 @@ class ProfilePage extends StatefulWidget {
               },
             )
           else
-            Container(width: double.infinity, height: 150, color: Theme.of(context).colorScheme.primary.withOpacity(0.1)),
+            Container(
+                width: double.infinity, height: 150, color: Theme.of(context).colorScheme.primary.withOpacity(0.1)),
 
+          // Profile Info Section
           Padding(
             padding: const EdgeInsets.all(16.0),
             child: Column(
@@ -93,7 +148,8 @@ class ProfilePage extends StatefulWidget {
                           backgroundImage: currentAccount.avatar != null && currentAccount.avatar!.isNotEmpty
                               ? NetworkImage(currentAccount.avatar!)
                               : null,
-                          onBackgroundImageError: currentAccount.avatar != null && currentAccount.avatar!.isNotEmpty ? (_, __) {} : null,
+                          onBackgroundImageError:
+                              currentAccount.avatar != null && currentAccount.avatar!.isNotEmpty ? (_, __) {} : null,
                           child: currentAccount.avatar == null || currentAccount.avatar!.isEmpty
                               ? Icon(Icons.person, size: 50)
                               : null,
@@ -104,33 +160,47 @@ class ProfilePage extends StatefulWidget {
                     ElevatedButton.icon(
                       icon: Icon(Icons.person_add_outlined),
                       label: Text("Follow"),
-                      onPressed: () { /* TODO */ },
+                      onPressed: () {/* TODO: Implement follow functionality */},
                     ),
                   ],
                 ),
-                SizedBox(height: 8),
+                SizedBox(height: 8), // Adjust space after avatar row
+
+                // Usernames and Display Name
                 Text(
                   currentAccount.displayName ?? currentAccount.username,
                   style: Theme.of(context).textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.bold),
+                  overflow: TextOverflow.ellipsis,
                 ),
                 if (currentAccount.acct != null)
-                  Text("@${currentAccount.acct}", style: Theme.of(context).textTheme.titleMedium?.copyWith(color: Colors.grey[600])),
+                  Text(
+                    "@${currentAccount.acct}",
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(color: Colors.grey[600]),
+                  ),
                 SizedBox(height: 16),
+
+                // User Note/Bio
                 if (currentAccount.note != null && currentAccount.note!.isNotEmpty)
                   HtmlRenderer(
                     html: currentAccount.note!,
                     onMentionTapped: (acctIdentifier) {
                       if (acctIdentifier == currentAccount.acct || "@${acctIdentifier}" == currentAccount.acct) {
-                        return;
+                        return; // Do nothing if it's the same profile
                       }
+                      // Navigate to a new ProfilePage, which will handle its own loading
                       Navigator.of(context).push(MaterialPageRoute(
                         builder: (context) => ProfilePage(acctIdentifier: acctIdentifier),
                       ));
                     },
                   )
                 else
-                  Text("No bio available.", style: TextStyle(fontStyle: FontStyle.italic, color: Colors.grey[600])),
+                  Text(
+                    "No bio available.",
+                    style: TextStyle(fontStyle: FontStyle.italic, color: Colors.grey[600]),
+                  ),
                 SizedBox(height: 24),
+
+                // User Stats
                 Row(
                   mainAxisAlignment: MainAxisAlignment.spaceAround,
                   children: [
@@ -165,45 +235,4 @@ class ProfilePage extends StatefulWidget {
     );
   }
 }
-class _ProfilePageState extends State<ProfilePage> {
-  MastodonAccountModel? _account;
-  bool _isLoading = true;
-  String? _error;
 
-  @override
-  void initState() {
-    super.initState();
-    if (widget.initialAccount != null) {
-      _account = widget.initialAccount;
-      _isLoading = false;
-    } else if (widget.acctIdentifier != null) {
-      _fetchAccountDetails();
-    } else {
-      _isLoading = false;
-      _error = "No account information provided.";
-    }
-  }
-
-  Future<void> _fetchAccountDetails() async {
-    if (widget.acctIdentifier == null) return;
-    setState(() {
-      _isLoading = true;
-      _error = null;
-    });
-    try {
-      final account = await MastodonAccountRepository.lookUpAccount(widget.acctIdentifier!);
-      if (mounted) {
-        setState(() {
-          _account = account;
-          _isLoading = false;
-        });
-      }
-    } catch (e) {
-      if (mounted) {
-        setState(() {
-          _error = "Failed to load profile: ${e.toString()}";
-          _isLoading = false;
-        });
-      }
-    }
-  }

--- a/lib/repositories/mastodon/account_repository.dart
+++ b/lib/repositories/mastodon/account_repository.dart
@@ -5,11 +5,46 @@ import 'package:fedi_pipe/repositories/mastodon/mastodon_base_repository.dart';
 
 class MastodonAccountRepository extends MastodonBaseRepository {
   static Future<MastodonAccountModel> lookUpAccount(String acct) async {
-    final response = await Client.get('/api/v1/accounts/lookup', queryParameters: {'acct': acct});
-    final json = jsonDecode(response.body);
-    final account = MastodonAccountModel.fromJson(json);
+    try {
+      if (acct.startsWith('@')) {
+        final account = await _tryLookUpRemoteAccount(acct);
+        if (account != null) {
+          return account;
+        }
+      }
+    } catch (e) {
+      print(e);
+    }
 
-    return account;
+    final localAccount = await _tryLookUpLocalAccount(acct);
+    return localAccount;
+  }
+
+  static Future<dynamic> _tryLookUpRemoteAccount(String acct) async {
+    try {
+      final response = await Client.get('/api/v1/accounts/lookup', queryParameters: {'acct': acct.substring(1)});
+      final json = jsonDecode(response.body);
+      final account = MastodonAccountModel.fromJson(json);
+
+      return account;
+    } catch (e) {
+      print(e);
+      return null;
+    }
+  }
+
+  static Future<dynamic> _tryLookUpLocalAccount(String acct) async {
+    final handle = acct.substring(1).split('@')[0];
+    try {
+      final response = await Client.get('/api/v1/accounts/lookup', queryParameters: {'acct': handle});
+      final json = jsonDecode(response.body);
+      final account = MastodonAccountModel.fromJson(json);
+
+      return account;
+    } catch (e) {
+      print(e);
+      return null;
+    }
   }
 
   static Future<List<MastodonAccountModel>> searchAccounts(String query) async {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -408,6 +408,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.1"
+  shimmer:
+    dependency: "direct main"
+    description:
+      name: shimmer
+      sha256: "5f88c883a22e9f9f299e5ba0e4f7e6054857224976a5d9f839d4ebdc94a14ac9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,6 +48,7 @@ dependencies:
   app_links: ^6.3.3
   flutter_secure_storage: ^9.2.4
   timeago: ^3.7.0
+  shimmer: ^3.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- **feat: add onMentionTapped callback to HtmlRenderer for mention handling**
- **feat: decouple mention tap handling in HtmlRenderer with callback parameter**
- **feat: provide onMentionTapped callback to HtmlRenderer in status card**
- **Refactor account lookup to handle remote and local accounts separately**
- **feat: implement onMentionTapped callback to navigate to ProfilePage**
- **feat: Implement onMentionTapped callback in ProfilePage for navigation**
- **feat: add shimmer package and create profile skeleton loading widget**
- **feat: Modify ProfilePage to accept acctIdentifier or initialAccount with loading state**
- **fix: add error handling in _fetchAccountDetails method**
- **feat: implement loading state with skeleton in MastodonProfileBottomSheet**
- **Complete**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added interactive profile mention support: tapping on a mention in posts or bios now opens a profile bottom sheet with loading and error states.
  - Introduced a skeleton loader for profile views to indicate loading progress.
- **Improvements**
  - Enhanced profile pages and bottom sheets with asynchronous loading, error handling, and improved layout for a smoother user experience.
- **Chores**
  - Added the `shimmer` package to enable animated loading skeletons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->